### PR TITLE
Minor fixes for compatibility with current rvar version (rvar-0.3.0.1)

### DIFF
--- a/genart/basic_usage.ipynb
+++ b/genart/basic_usage.ipynb
@@ -68,9 +68,9 @@
     "randomVariable = (*) <$> randomPareto <*> randomNormal\n",
     "\n",
     "sampleNormal :: State StdGen Double\n",
-    "sampleNormal = sampleRVar randomNormal\n",
+    "sampleNormal = sampleStateRVar randomNormal\n",
     "\n",
-    "sampleVariable = sampleRVar randomVariable\n",
+    "sampleVariable = sampleStateRVar randomVariable\n",
     "\n",
     "evalState sampleNormal $ mkStdGen 1\n",
     "evalState sampleVariable $ mkStdGen 1"
@@ -111,7 +111,7 @@
     "  return $ position (zip points bubbles)\n",
     "          \n",
     "-- (MonadRandom m, ...) m a\n",
-    "sampleBubbles n = sampleRVar $ randBubbles n\n",
+    "sampleBubbles n = sampleStateRVar $ randBubbles n\n",
     "\n",
     "withImgHeight 500 $ diagram $ evalState (sampleBubbles 9000) $ mkStdGen 1"
    ]
@@ -159,7 +159,7 @@
     "  return $ position (zip points pearls)\n",
     "          \n",
     "-- (MonadRandom m, ...) m a\n",
-    "samplePearls n = sampleRVar $ randPearls n\n",
+    "samplePearls n = sampleStateRVar $ randPearls n\n",
     "\n",
     "diagramPearls n = evalState (samplePearls n) $ mkStdGen 1\n",
     "\n",
@@ -194,7 +194,7 @@
     "  return $ hcat' distrib $ map (vcat' distrib) grid\n",
     "    where distrib = (with & catMethod .~ Distrib & sep .~ 80)\n",
     "  \n",
-    "sampleBubbleSheet k n = sampleRVar $ randBubbleSheet k n\n",
+    "sampleBubbleSheet k n = sampleStateRVar $ randBubbleSheet k n\n",
     "\n",
     "withImgHeight 500 $ diagram $ evalState (sampleBubbleSheet 10 600) $ mkStdGen 1"
    ]
@@ -225,7 +225,7 @@
     "  return $ mconcat $ map drawLine walk\n",
     "  \n",
     "sampleAndDraw seed randomDiagram = withImgHeight 500 $ diagram $ d\n",
-    "  where d = evalState (sampleRVar randomDiagram) $ mkStdGen seed"
+    "  where d = evalState (sampleStateRVar randomDiagram) $ mkStdGen seed"
    ]
   },
   {

--- a/genart/stack_v1.ipynb
+++ b/genart/stack_v1.ipynb
@@ -100,7 +100,7 @@
     "              -> ManuallySized (QDiagram Cairo V2 Double Any) -- draws diagram\n",
     "              \n",
     "sampleAndDraw seed randomDiagram = withImgHeight 500 $ diagram d\n",
-    "  where d = evalState (sampleRVar randomDiagram) $ mkStdGen seed"
+    "  where d = evalState (sampleStateRVar randomDiagram) $ mkStdGen seed"
    ]
   },
   {

--- a/genart/stack_v2.ipynb
+++ b/genart/stack_v2.ipynb
@@ -83,7 +83,7 @@
    },
    "outputs": [],
    "source": [
-    "sampleArtist seed laws env artist = State.evalState (sampleRVar randomDrawing) $ mkStdGen 1\n",
+    "sampleArtist seed laws env artist = State.evalState (sampleStateRVar randomDrawing) $ mkStdGen 1\n",
     "  where randomDrawing = snd <$> execRWST artist laws env -- execRWST returns RVar (state, writer)"
    ]
   },


### PR DESCRIPTION
See https://hackage.haskell.org/package/rvar-0.3.0.1/docs/Data-RVar.html

"sampleRVar" was renamed to "sampleStateRVar".
